### PR TITLE
Исправлена ошибка UnicodeEncodeError при запуске на Windows 

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ def text_recognition(file_path, text_file_name="result.txt"):
     reader = easyocr.Reader(["ru", "en"])
     result = reader.readtext(file_path, detail=0, paragraph=True)
     
-    with open(text_file_name, "w") as file:
+    with open(text_file_name, "w", encoding="utf-8") as file:
         for line in result:
             file.write(f"{line}\n\n")
     


### PR DESCRIPTION
При попытке запуска на windows 11, скрипт падал с ошибкой: `UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-5: character maps to <undefined>`